### PR TITLE
Fix README.md and bin/console

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,18 @@ Example of usage
 require 'power_point_pptx'
 
 # Open an existing PowerPoint presentation
-presentation = PowerPointPptx::Document.open('path/to/presentation.pptx')
+pptx_file = 'path/to/presentation.pptx'
+presentation = PowerPointPptx::Document.open(pptx_file)
 
 # Get the first slide
 slide = presentation.slides.first
 
 # Retrieve content slide
-slide.contents
+slide.content
 
 # Change content
 
-slide.contents = ["This is a new content]
+slide.content = ["This is a new content]
 
 # Stream the new version and save it in a temporary file
 

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "pptx"
+require "power_point_pptx"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.


### PR DESCRIPTION
- Fix ```.open``` attribute from string path to a File object, and typo on contents method
- Update require statement on ```bin/console``` to use the correct gem name 'power_point_pptx' instead of 'pptx'